### PR TITLE
Add option to change PHP server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Default value: process.cwd()
 
 Specify a docroot for the php Server. All php files will be served relative to this directory.
 
+#### options.serverPort
+Type: `Int`
+Default value: `8888`
+
+Specify a port for the php Server.
+
 
 ### Usage Examples
 

--- a/tasks/php2html.js
+++ b/tasks/php2html.js
@@ -33,7 +33,8 @@ module.exports = function (grunt) {
 				processLinks: true,
 				process: false,
 				htmlhint: undefined,
-				docroot: undefined
+				docroot: undefined,
+				serverPort: 8888
 			});
 
 		// nothing to do
@@ -150,7 +151,7 @@ module.exports = function (grunt) {
 				grunt.log.write('Processing ' + file +'...');
 
 
-				compilePhp(uri, function (response, err) {
+				compilePhp(options.serverPort, uri, function (response, err) {
 
 					// replace relative php links with corresponding html link
 					if (response && options.processLinks) {
@@ -224,12 +225,13 @@ module.exports = function (grunt) {
 
 	/**
 	 * Use server with gateway middleware to generate html for the given source
+	 * @param {int} port
 	 * @param {string} uri
 	 * @param {function} callback
 	 */
-	var compilePhp = function (uri, callback) {
-		app.listen(8888);
-		request('http://localhost:8888' + uri, function (error, response, body) {
+	var compilePhp = function (port, uri, callback) {
+		app.listen(port);
+		request('http://localhost:'+ port + uri, function (error, response, body) {
 			app.close();
 			callback(body,error);
 		}).end();


### PR DESCRIPTION
I added a new option to specify the port number on which the PHP server will run, since I had other services running on port `8888`.
