### PR TITLE
use htmlspecialchars with PHP_SELF

### DIFF
--- a/test/env/PHP_SELF.php
+++ b/test/env/PHP_SELF.php
@@ -1,1 +1,1 @@
-<?php print_r($_SERVER['PHP_SELF']);
+<?php print_r(htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'utf-8'));


### PR DESCRIPTION
The security scanner Wapiti claimed that $_SERVER['PHP_SELF'] is vulnerable to XSS.
Using htmlspecialchars fixes that, see https://stackoverflow.com/questions/6080022/php-self-and-xss.
